### PR TITLE
Fix vulnerabilities and expose metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ npm run docker:dev
 - Web界面: http://localhost:3000
 - API文档: http://localhost:3000/api
 - 健康检查: http://localhost:3000/health
+- 指标监控: http://localhost:3000/api/metrics
 
 ### 方式二：本地部署
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,13 @@
     "lint": "eslint src/",
     "test": "jest"
   },
-  "keywords": ["youtube", "automation", "video", "editing", "ai"],
+  "keywords": [
+    "youtube",
+    "automation",
+    "video",
+    "editing",
+    "ai"
+  ],
   "author": "",
   "license": "MIT",
   "dependencies": {
@@ -32,7 +38,7 @@
     "ffmpeg-static": "^5.2.0",
     "fluent-ffmpeg": "^2.1.2",
     "googleapis": "^126.0.1",
-    "puppeteer": "^21.5.0",
+    "puppeteer": "^24.15.0",
     "winston": "^3.11.0",
     "youtube-dl-exec": "^2.4.13",
     "node-cron": "^3.0.2",

--- a/src/services/youtube.js
+++ b/src/services/youtube.js
@@ -60,7 +60,11 @@ class YouTubeService {
       this.oauth2Client.setCredentials(tokens);
       
       const tokenPath = path.join(process.cwd(), 'youtube_token.json');
-      await fs.writeFile(tokenPath, JSON.stringify(tokens, null, 2));
+      await fs.writeFile(
+        tokenPath,
+        JSON.stringify(tokens, null, 2),
+        { mode: 0o600 }
+      );
       
       this.isAuthenticated = true;
       logger.info('YouTube认证成功');

--- a/src/web/app.js
+++ b/src/web/app.js
@@ -11,6 +11,7 @@ const { body, validationResult } = require('express-validator');
 const YouTubeAutomation = require('../modules/automation');
 const queueService = require('../services/queue');
 const cacheService = require('../services/cache');
+const metricsService = require('../services/metrics');
 const { logger, ErrorHandler } = require('../utils/logger');
 const config = require('../config');
 
@@ -126,6 +127,22 @@ class WebApplication {
       } catch (error) {
         ErrorHandler.handle(error, 'API: 获取系统状态');
         res.status(500).json({ error: '获取系统状态失败' });
+      }
+    });
+
+    // 系统指标
+    router.get('/metrics', (req, res) => {
+      try {
+        const format = req.query.format === 'prometheus' ? 'prometheus' : 'json';
+        const data = metricsService.exportMetrics(format);
+        if (format === 'prometheus') {
+          res.type('text/plain').send(data);
+        } else {
+          res.type('application/json').send(data);
+        }
+      } catch (error) {
+        ErrorHandler.handle(error, 'API: 获取指标');
+        res.status(500).json({ error: '获取指标失败' });
       }
     });
 

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -169,6 +169,12 @@
                 <!-- 日志信息将在这里显示 -->
             </div>
         </div>
+
+        <!-- 指标监控 -->
+        <div class="bg-white rounded-lg shadow p-6 mt-8">
+            <h2 class="text-xl font-bold text-gray-800 mb-4">系统指标</h2>
+            <pre id="metrics" class="text-sm bg-gray-50 p-4 rounded overflow-x-auto"></pre>
+        </div>
     </div>
 
     <!-- 通知容器 -->

--- a/src/web/public/script.js
+++ b/src/web/public/script.js
@@ -8,6 +8,7 @@ class YouTubeAutomationUI {
 
     init() {
         this.loadSystemStatus();
+        this.loadMetrics();
         this.startStatusUpdates();
     }
 
@@ -58,6 +59,16 @@ class YouTubeAutomationUI {
             this.updateSystemStatus(data);
         } catch (error) {
             this.log(`加载系统状态失败: ${error.message}`, 'error');
+        }
+    }
+
+    async loadMetrics() {
+        try {
+            const response = await fetch('/api/metrics');
+            const text = await response.text();
+            document.getElementById('metrics').textContent = text;
+        } catch (error) {
+            this.log(`加载指标失败: ${error.message}`, 'error');
         }
     }
 
@@ -372,6 +383,7 @@ class YouTubeAutomationUI {
         // 定期更新系统状态
         setInterval(() => {
             this.loadSystemStatus();
+            this.loadMetrics();
         }, 30000); // 每30秒更新一次
     }
 }


### PR DESCRIPTION
## Summary
- update puppeteer to fix vulnerabilities
- secure youtube token file permissions
- expose `/api/metrics` endpoint
- display metrics in the web UI

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6886f7fe9cd08322a6b5f2f4a2c74ce2